### PR TITLE
Extend braze resources with last_edited data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 pkg/
 Gemfile.lock
+txbr-*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.7.0
+* Add last_edited as last_edited to campaign instance metadata
+* add updated_at as last_edited to email template instance metadata
+* Change initializer for Txbr::Campaign and Txbr::EmailTemplate
+
 # 2.6.1
 * Exclude archived campaigns from Braze with "include_archived: false" parameter.
 

--- a/lib/txbr/campaign.rb
+++ b/lib/txbr/campaign.rb
@@ -7,9 +7,10 @@ module Txbr
 
     attr_reader :project, :campaign_id
 
-    def initialize(project, campaign_id)
+    def initialize(project, campaign_data)
       @project = project
-      @campaign_id = campaign_id
+      @campaign_data = campaign_data
+      @campaign_id = campaign_data['id']
     end
 
     def each_resource(&block)
@@ -21,7 +22,8 @@ module Txbr
       @metadata ||= {
         item_type: ITEM_TYPE,
         campaign_name: campaign_name,
-        campaign_id: campaign_id
+        campaign_id: campaign_id,
+        last_edited: last_edited
       }
     rescue => e
       {}
@@ -34,6 +36,12 @@ module Txbr
     end
 
     private
+
+    attr_reader :campaign_data
+
+    def last_edited
+      campaign_data['last_edited']
+    end
 
     def template_group
       @template_group ||= TemplateGroup.new(campaign_name, templates, project)

--- a/lib/txbr/campaign_handler.rb
+++ b/lib/txbr/campaign_handler.rb
@@ -14,8 +14,8 @@ module Txbr
     def each_campaign
       return to_enum(__method__) unless block_given?
 
-      project.braze_api.campaigns.each do |campaign|
-        yield Campaign.new(project, campaign['id'])
+      project.braze_api.campaigns.each do |campaign_data|
+        yield Campaign.new(project, campaign_data)
       end
     end
 

--- a/lib/txbr/email_template.rb
+++ b/lib/txbr/email_template.rb
@@ -8,9 +8,10 @@ module Txbr
 
     attr_reader :project, :email_template_id
 
-    def initialize(project, email_template_id)
+    def initialize(project, tmpl_data)
       @project = project
-      @email_template_id = email_template_id
+      @tmpl_data = tmpl_data
+      @email_template_id = tmpl_data['email_template_id']
     end
 
     def each_resource(&block)
@@ -22,13 +23,20 @@ module Txbr
       @metadata ||= {
         item_type: ITEM_TYPE,
         template_name: template_name,
-        template_id: email_template_id
+        template_id: email_template_id,
+        last_edited: last_edited
       }
     rescue => e
       {}
     end
 
     private
+
+    attr_reader :tmpl_data
+
+    def last_edited
+      tmpl_data['updated_at']
+    end
 
     def template_group
       @template_group ||= TemplateGroup.new(template_name, templates, project)

--- a/lib/txbr/email_template_handler.rb
+++ b/lib/txbr/email_template_handler.rb
@@ -17,8 +17,8 @@ module Txbr
     def each_template
       return to_enum(__method__) unless block_given?
 
-      project.braze_api.email_templates.each do |tmpl|
-        yield EmailTemplate.new(project, tmpl['email_template_id'])
+      project.braze_api.email_templates.each do |tmpl_data|
+        yield EmailTemplate.new(project, tmpl_data)
       end
     end
 

--- a/lib/txbr/version.rb
+++ b/lib/txbr/version.rb
@@ -1,3 +1,3 @@
 module Txbr
-  VERSION = '2.6.1'
+  VERSION = '2.7.0'
 end

--- a/spec/campaign_spec.rb
+++ b/spec/campaign_spec.rb
@@ -6,7 +6,9 @@ describe Txbr::Campaign do
   include_context 'standard setup'
 
   let(:campaign_id) { 'abc123' }
-  let(:campaign) { described_class.new(project, campaign_id) }
+  let(:last_edited) { '2021-03-18T16:20:57+00:00' }
+  let(:campaign_data) { Hash['id', campaign_id, 'last_edited', last_edited] }
+  let(:campaign) { described_class.new(project, campaign_data) }
 
   let(:first_message) do
     <<~MESSAGE
@@ -154,7 +156,8 @@ describe Txbr::Campaign do
       expect(campaign.metadata).to eq(
         item_type: 'campaign',
         campaign_name: 'World Domination',
-        campaign_id: campaign_id
+        campaign_id: campaign_id,
+        last_edited: last_edited
       )
     end
   end

--- a/spec/email_template_spec.rb
+++ b/spec/email_template_spec.rb
@@ -6,7 +6,9 @@ describe Txbr::EmailTemplate do
   include_context 'standard setup'
 
   let(:email_template_id) { 'abc123' }
-  let(:email_template) { described_class.new(project, email_template_id) }
+  let(:last_edited) { '2021-03-18T16:20:57+00:00' }
+  let(:tmpl_data) { Hash['email_template_id', email_template_id, 'updated_at', last_edited] }
+  let(:email_template) { described_class.new(project, tmpl_data) }
 
   let(:body_html) do
     <<~HTML
@@ -182,7 +184,8 @@ describe Txbr::EmailTemplate do
       expect(email_template.metadata).to eq(
         item_type: 'email_template',
         template_name: 'Super Slick Awesome',
-        template_id: email_template_id
+        template_id: email_template_id,
+        last_edited: last_edited
       )
     end
   end


### PR DESCRIPTION
Braze responds to us in campaigns and email_templates with last_edited and updated_at fields.
Those fields are useful to understand how long ago the resource was changed.